### PR TITLE
bugfix: added missing comma in model.json file for Pyspark Log Reg

### DIFF
--- a/model_definitions/149e31ed-c554-46b4-95d2-00c5c43320fb/model.json
+++ b/model_definitions/149e31ed-c554-46b4-95d2-00c5c43320fb/model.json
@@ -5,7 +5,7 @@
     "language": "python",
 
     "automation": {
-        "trainingEngine": "pyspark"
+        "trainingEngine": "pyspark",
         "resources": {
             "master": "local[1]",
             "args": "--num-executors 1 --executor-cores 1 --driver-memory 1G --executor-memory 1G"


### PR DESCRIPTION
bugfix: added missing comma in model.json file for Pyspark Log Reg

Note: no linked issue, as I don't know if I'm able to create one.