### PR TITLE
Fix R GBM model for ATs #94

### DIFF
--- a/model_definitions/bf6a52b2-b595-4358-ac4f-24fb41a85c45/model_modules/evaluation.R
+++ b/model_definitions/bf6a52b2-b595-4358-ac4f-24fb41a85c45/model_modules/evaluation.R
@@ -33,7 +33,7 @@ evaluate <- function(data_conf, model_conf, ...) {
   con <- Connect2Vantage()
 
   # Create tibble from table in Vantage
-  if (data_conf$schema) {
+  if ("schema" %in% data_conf)
     table_name <- in_schema(data_conf$schema, data_conf$table)
   } else {
     table_name <- data_conf$table

--- a/model_definitions/bf6a52b2-b595-4358-ac4f-24fb41a85c45/model_modules/scoring.R
+++ b/model_definitions/bf6a52b2-b595-4358-ac4f-24fb41a85c45/model_modules/scoring.R
@@ -41,7 +41,7 @@ score.batch <- function(data_conf, model_conf, model_version, ...) {
     con <- Connect2Vantage()
 
     # Create tibble from table in Teradata Vantage
-    if (data_conf$schema) {
+    if ("schema" %in% data_conf)
         table_name <- in_schema(data_conf$schema, data_conf$table)
     } else {
         table_name <- data_conf$table

--- a/model_definitions/bf6a52b2-b595-4358-ac4f-24fb41a85c45/model_modules/training.R
+++ b/model_definitions/bf6a52b2-b595-4358-ac4f-24fb41a85c45/model_modules/training.R
@@ -29,7 +29,7 @@ train <- function(data_conf, model_conf, ...) {
     con <- Connect2Vantage()
 
     # Create tibble from table in Vantage
-    if (data_conf$schema) {
+    if ("schema" %in% data_conf)
         table_name <- in_schema(data_conf$schema, data_conf$table)
     } else {
         table_name <- data_conf$table


### PR DESCRIPTION
This is a fix for my own creation regarding the code to add the schema on the vantage connection if provided in data_conf. It was failing if no `data_conf$schema` was provided.

This was also causing ATs to fail 

closes #94 